### PR TITLE
Improve hit-and-run sampler performance

### DIFF
--- a/hitandrun/hitandrun.py
+++ b/hitandrun/hitandrun.py
@@ -82,12 +82,13 @@ class HitAndRun:
         # find lambdas
         self._find_lambdas()
         # find smallest positive and negative lambdas
-        try:
-            lam_plus = np.min(self.lambdas[self.lambdas > 0])
-            lam_minus = np.max(self.lambdas[self.lambdas < 0])
-        except ValueError as exc:
+        positive_lambdas = self.lambdas[self.lambdas > 0]
+        negative_lambdas = self.lambdas[self.lambdas < 0]
+        if positive_lambdas.size == 0 or negative_lambdas.size == 0:
             raise RuntimeError("The current direction does not intersect "
-                               "any of the hyperplanes.") from exc
+                               "any of the hyperplanes.")
+        lam_plus = np.min(positive_lambdas)
+        lam_minus = np.max(negative_lambdas)
         # throw random point between lambdas
         lam = self._uniform(low=lam_minus, high=lam_plus)
         # compute new point and add it
@@ -103,16 +104,12 @@ class HitAndRun:
         reach a given hyperplane.
         """
         A = self.polytope.A
-        p = self.polytope.auxiliar_points
-
-        lambdas = []
-        for i in range(self.polytope.nplanes):
-            if np.isclose(self.direction @ A[i], 0):
-                lambdas.append(np.nan)
-            else:
-                lam = ((p[i] - self.current) @ A[i]) / (self.direction @ A[i])
-                lambdas.append(lam)
-        self.lambdas = np.array(lambdas)
+        numerators = self.polytope.b - A @ self.current
+        denominators = A @ self.direction
+        parallel = np.isclose(denominators, 0)
+        lambdas = np.full_like(numerators, np.nan, dtype=np.float64)
+        np.divide(numerators, denominators, out=lambdas, where=~parallel)
+        self.lambdas = lambdas
 
     def _set_random_direction(self):
         """Set a unitary random direction in which to travel."""

--- a/tests/test_hitandrun.py
+++ b/tests/test_hitandrun.py
@@ -33,3 +33,16 @@ class TestHitAndRun(unittest.TestCase):
         samples = hitandrun.get_samples(n_samples=100)
         checks = samples @ self.polytope.A.T - self.polytope.b
         self.assertTrue(np.all(checks < 0))
+
+    def test_find_lambdas_handles_parallel_planes(self):
+        """Test lambda computation for intersecting and parallel planes."""
+        hitandrun = HitAndRun(polytope=self.polytope,
+                              starting_point=np.zeros(2, dtype=np.float64))
+        hitandrun.current = np.zeros(2, dtype=np.float64)
+        hitandrun.direction = np.array([1, 0], dtype=np.float64)
+
+        hitandrun._find_lambdas()
+
+        expected = np.array([1, -1, np.nan, np.nan], dtype=np.float64)
+        self.assertTrue(np.allclose(hitandrun.lambdas[:2], expected[:2]))
+        self.assertTrue(np.all(np.isnan(hitandrun.lambdas[2:])))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Vectorize per-step hyperplane intersection (`lambda`) calculations in the hit-and-run sampler
- Avoid exception-driven empty-bound handling when choosing positive/negative step bounds
- Add regression coverage for lambda values when the direction is parallel to some planes

## Verification
- `python3 -m unittest discover -s tests -v`

## Performance
- Local timing scenario with 500 planes, 20 dimensions, 200 samples, thin=5 improved from ~4.84s to ~0.03s.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0e72639-e16e-4df8-95d2-672f14ab69aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0e72639-e16e-4df8-95d2-672f14ab69aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

