### PR TITLE
Set up development environment (AGENTS.md + venv-based tooling)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,11 @@ __pycache__/
 *$py.class
 # Unit test / coverage reports
 .pytest_cache/
+# Virtual environments
+.venv/
+venv/
+# Packaging / build artifacts
+*.egg-info/
+build/
+dist/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`hitandrun` is a pure-Python library (no servers, databases, or GUI) for uniformly
+sampling convex polytopes with the Hit-and-Run algorithm. Public API lives in
+`hitandrun/__init__.py` (`Polytope`, `HitAndRun`, `MinOver`).
+
+Dependencies are installed into a virtualenv at `.venv` by the startup update
+script. Activate it before running anything:
+
+```bash
+. .venv/bin/activate
+```
+
+- Test: `python -m unittest discover -s tests -v` (the documented runner; `pytest` also works).
+- Lint: not configured in-repo; `flake8` is installed for convenience.
+- "Run" the library: import it and sample a polytope, e.g.
+  ```python
+  import numpy as np
+  from hitandrun import HitAndRun, Polytope
+  A = np.array([[1,0],[-1,0],[0,1],[0,-1]], dtype=np.float64)
+  b = np.array([1,1,1,1], dtype=np.float64)
+  s = HitAndRun(polytope=Polytope(A=A, b=b), starting_point=np.zeros(2))
+  print(s.get_samples(n_samples=100))
+  ```
+
+Note: the optional `tqdm` progress bar is auto-enabled when the `progress` extra
+is installed (it is, via the update script). Pass an explicit `rng=` to
+`HitAndRun` for reproducible samples.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the `hitandrun` Python library and documents it for future Cursor Cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering venv activation, test/lint/run commands, and non-obvious notes (tqdm progress extra, reproducible `rng=`).
- Environment is installed into a `.venv` virtualenv via the configured startup update script (`pip install -e ".[progress]"` plus `flake8`/`pytest` dev tooling).

## Verification

All checks run inside the `.venv`:

- ✅ `python -m unittest discover -s tests -v` — 10 passed
- ✅ `python -m pytest -q` — 10 passed
- ✅ `flake8 hitandrun tests --max-line-length=100` — clean (exit 0)
- ✅ Hello-world: sampled the unit-square polytope (5000 samples), all points inside, mean ≈ (0, 0)

[hitandrun_verification.log](https://cursor.com/agents/bc-51753bc9-f5f7-44ea-bf61-8c87d9640a2b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhitandrun_verification.log)

Note: this is a pure-Python library (no server/GUI), so evidence is via test/CLI output rather than a UI walkthrough.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51753bc9-f5f7-44ea-bf61-8c87d9640a2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51753bc9-f5f7-44ea-bf61-8c87d9640a2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

