### PR TITLE
Add automatic feasible starting points

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ sampler = HitAndRun(polytope=polytope, starting_point=x0)
 samples = sampler.get_samples(n_samples=100)
 ```
 
+If you do not already have a feasible initial condition, omit
+`starting_point`. `HitAndRun` will draw a random initial guess and use `MinOver`
+to find a feasible point for the chain:
+
+```python
+sampler = HitAndRun(polytope=polytope, rng=np.random.default_rng(0))
+```
+
+This automatic starting point is feasible, but it is not a uniform sample from
+the polytope.
+
 ## Notebook
 
 See `notebooks/hitandrun_usage.ipynb` for a plotted walkthrough of defining a

--- a/hitandrun/hitandrun.py
+++ b/hitandrun/hitandrun.py
@@ -7,6 +7,8 @@ Oct 2018
 import numpy as np
 from numpy.linalg import norm
 
+from hitandrun.minover import MinOver
+
 
 class HitAndRun:
     """Hit-and-run sampler."""
@@ -20,8 +22,9 @@ class HitAndRun:
         ----------
         polytope: hitandrun.polytope
             The convex polytope to be sampled.
-        starting_point: np.array
-            Initial condition. Must be inside the polytope.
+        starting_point: np.array, optional
+            Initial condition. Must be inside the polytope. If omitted, a
+            random feasible point is found with MinOver.
         n_samples: int
             Number of desired samples.
         thin : int
@@ -31,24 +34,25 @@ class HitAndRun:
             random module to preserve existing seeding behavior.
 
         """
-        # make sure we got a point inside the polytope
         if polytope is None:
             raise ValueError("polytope must be provided.")
-        if starting_point is None:
-            raise ValueError("starting_point must be provided.")
 
-        starting_point = np.asarray(starting_point)
+        self.polytope = polytope
+        self.n_samples = n_samples
+        self.thin = thin
+        self.rng = rng
+
+        if starting_point is None:
+            starting_point = self._find_random_starting_point()
+        else:
+            starting_point = np.asarray(starting_point)
 
         if len(starting_point) != polytope.dim:
             raise ValueError("starting_point must match the polytope dimension.")
         if not polytope.check_inside(starting_point):
             raise ValueError("starting_point must be inside the polytope.")
 
-        self.polytope = polytope
         self.starting_point = starting_point
-        self.n_samples = n_samples
-        self.thin = thin
-        self.rng = rng
         # place starting point as current point
         self.current = starting_point.copy()
         # set a starting random direction
@@ -75,6 +79,22 @@ class HitAndRun:
         return np.array(self.samples)
 
     # private functions
+    def _find_random_starting_point(self):
+        """
+        Find a feasible starting point from a random initial guess.
+
+        The point is intended as a valid initial condition for the Markov chain;
+        it is not a uniform draw from the polytope.
+        """
+        initial = self._normal(size=self.polytope.dim)
+        if self.polytope.check_inside(initial):
+            return initial
+
+        point, convergence = MinOver(self.polytope).run(starting_point=initial)
+        if not convergence:
+            raise ValueError("could not find a feasible starting_point.")
+        return point
+
     def _step(self):
         """Make one step."""
         # set random direction

--- a/tests/test_hitandrun.py
+++ b/tests/test_hitandrun.py
@@ -34,6 +34,37 @@ class TestHitAndRun(unittest.TestCase):
         checks = samples @ self.polytope.A.T - self.polytope.b
         self.assertTrue(np.all(checks < 0))
 
+    def test_hitandrun_finds_random_starting_point(self):
+        """Test if HitAndRun can find a feasible starting point."""
+        rng = np.random.default_rng(3)
+        hitandrun = HitAndRun(polytope=self.polytope, rng=rng)
+
+        self.assertTrue(self.polytope.check_inside(hitandrun.starting_point))
+
+        samples = hitandrun.get_samples(n_samples=100)
+        checks = samples @ self.polytope.A.T - self.polytope.b
+        self.assertTrue(np.all(checks < 0))
+
+    def test_hitandrun_random_starting_point_uses_rng(self):
+        """Test if automatic starting points are reproducible."""
+        sampler0 = HitAndRun(polytope=self.polytope,
+                             rng=np.random.default_rng(3))
+        sampler1 = HitAndRun(polytope=self.polytope,
+                             rng=np.random.default_rng(3))
+
+        self.assertTrue(np.allclose(sampler0.starting_point,
+                                    sampler1.starting_point))
+
+    def test_hitandrun_random_starting_point_requires_feasible_polytope(self):
+        """Test if infeasible polytopes fail automatic initialization."""
+        A = np.array([[1],
+                      [-1]], dtype=np.float64)
+        b = np.array([0, -1], dtype=np.float64)
+        polytope = Polytope(A=A, b=b)
+
+        with self.assertRaisesRegex(ValueError, "feasible starting_point"):
+            HitAndRun(polytope=polytope, rng=np.random.default_rng(3))
+
     def test_find_lambdas_handles_parallel_planes(self):
         """Test lambda computation for intersecting and parallel planes."""
         hitandrun = HitAndRun(polytope=self.polytope,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Allow `HitAndRun` to initialize without an explicit `starting_point` by finding a feasible point from a random initial guess with `MinOver`.
- Preserve explicit starting point validation and document that the automatic point is feasible, not uniformly sampled.
- Add unit coverage for automatic initialization, reproducibility, sampling, and infeasible polytopes.

## Testing
- Pending post-push validation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-acec027c-bc41-456f-abc9-cac6b44a7159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-acec027c-bc41-456f-abc9-cac6b44a7159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

